### PR TITLE
Respond to OpenAI webhooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ Environment variables required:
 - `RECORDING_ENABLED`: Enable HTTP recording (default: false)
 - `RECORDING_LOG_PATH`: Recording log file path (default: recordings.jsonl)
 - `STATUS_AUTH_TOKEN`: Bearer token for /status endpoint authentication (if not set, endpoint is disabled)
+- `OPENAI_WEBHOOK_SECRET`: Signing secret for OpenAI webhook verification (if not set, `/openai-webhook` endpoint returns 503). Configure webhooks in the OpenAI dashboard to receive real-time batch completion notifications instead of polling.
 
 
 ### Review Dashboard

--- a/robocop-server/src/batch_processor.rs
+++ b/robocop-server/src/batch_processor.rs
@@ -87,7 +87,10 @@ async fn create_and_process_event(
     Ok(())
 }
 
-async fn process_single_batch(
+/// Process a single batch by checking its status and generating the appropriate event.
+///
+/// This is called by both the polling loop and the OpenAI webhook handler.
+pub async fn process_single_batch(
     state: &Arc<AppState>,
     pr_id: &crate::state_machine::StateMachinePrId,
     batch_id: &crate::state_machine::BatchId,

--- a/robocop-server/src/config.rs
+++ b/robocop-server/src/config.rs
@@ -19,6 +19,11 @@ pub struct Config {
     /// If set, requests to /status must include `Authorization: Bearer <token>`.
     /// If not set, /status endpoint is disabled (returns 403 Forbidden).
     pub status_auth_token: Option<String>,
+    /// Optional signing secret for OpenAI webhook verification.
+    /// If set, enables the /openai-webhook endpoint for real-time batch completions.
+    /// If not set, /openai-webhook endpoint returns 503 Service Unavailable.
+    /// Secret is base64-encoded and may have "whsec_" prefix.
+    pub openai_webhook_secret: Option<String>,
 }
 
 impl Config {
@@ -69,6 +74,17 @@ impl Config {
             }
         });
 
+        // OpenAI webhook secret for real-time batch completion notifications.
+        // If not set, the /openai-webhook endpoint will return 503.
+        let openai_webhook_secret = env::var("OPENAI_WEBHOOK_SECRET").ok().and_then(|s| {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        });
+
         Ok(Config {
             github_app_id,
             github_private_key,
@@ -80,6 +96,7 @@ impl Config {
             recording_log_path,
             state_dir,
             status_auth_token,
+            openai_webhook_secret,
         })
     }
 }

--- a/robocop-server/src/lib.rs
+++ b/robocop-server/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod git;
 pub mod github;
 pub mod openai;
+pub mod openai_webhook;
 pub mod reconciliation;
 pub mod review_state;
 pub mod state_machine;
@@ -46,4 +47,8 @@ pub struct AppState {
     /// If `Some`, requests must include `Authorization: Bearer <token>`.
     /// If `None`, /status endpoint is disabled (returns 403 Forbidden).
     pub status_auth_token: Option<String>,
+    /// Optional signing secret for OpenAI webhook verification.
+    /// If `Some`, webhooks are verified using the Standard Webhooks spec.
+    /// If `None`, /openai-webhook endpoint returns 503 Service Unavailable.
+    pub openai_webhook_secret: Option<String>,
 }

--- a/robocop-server/src/main.rs
+++ b/robocop-server/src/main.rs
@@ -68,6 +68,13 @@ async fn help_handler(headers: HeaderMap) -> Response {
                 "response_format": "application/json"
             },
             {
+                "path": "/openai-webhook",
+                "method": "POST",
+                "description": "OpenAI webhook receiver for batch completion events (Standard Webhooks spec)",
+                "authentication": "Standard Webhooks signature verification (requires OPENAI_WEBHOOK_SECRET)",
+                "response_format": "application/json"
+            },
+            {
                 "path": "/help",
                 "method": "GET",
                 "description": "API documentation and service information",
@@ -105,7 +112,8 @@ async fn help_handler(headers: HeaderMap) -> Response {
                 "STATE_DIR (default: current directory)",
                 "RECORDING_ENABLED (default: false)",
                 "RECORDING_LOG_PATH (default: recordings.jsonl)",
-                "STATUS_AUTH_TOKEN (required to enable /status endpoint)"
+                "STATUS_AUTH_TOKEN (required to enable /status endpoint)",
+                "OPENAI_WEBHOOK_SECRET (required to enable /openai-webhook endpoint)"
             ]
         },
         "documentation": "https://github.com/Smaug123/robocop"

--- a/robocop-server/src/main.rs
+++ b/robocop-server/src/main.rs
@@ -20,6 +20,7 @@ use robocop_server::batch_processor::batch_polling_loop;
 use robocop_server::config::Config;
 use robocop_server::github::GitHubClient;
 use robocop_server::openai::OpenAIClient;
+use robocop_server::openai_webhook::openai_webhook_router;
 use robocop_server::reconciliation::reconcile_orphaned_batches;
 use robocop_server::state_machine::repository::SqliteRepository;
 use robocop_server::webhook::webhook_router;
@@ -325,6 +326,15 @@ async fn main() -> Result<()> {
         info!("STATUS_AUTH_TOKEN not set: /status endpoint is disabled");
     }
 
+    // Log info about OpenAI webhook configuration
+    if config.openai_webhook_secret.is_some() {
+        info!("OPENAI_WEBHOOK_SECRET set: /openai-webhook endpoint enabled");
+    } else {
+        info!(
+            "OPENAI_WEBHOOK_SECRET not set: /openai-webhook endpoint disabled (using polling only)"
+        );
+    }
+
     let app_state = Arc::new(AppState {
         github_client: Arc::new(github_client),
         openai_client: Arc::new(openai_client),
@@ -334,6 +344,7 @@ async fn main() -> Result<()> {
         state_store: Arc::new(StateStore::with_repository(Arc::new(sqlite_repo))),
         recording_logger,
         status_auth_token: config.status_auth_token,
+        openai_webhook_secret: config.openai_webhook_secret,
     });
 
     // Run crash recovery reconciliation before accepting any requests
@@ -345,6 +356,7 @@ async fn main() -> Result<()> {
         .route("/help", get(help_handler))
         .route("/status", get(status_handler))
         .merge(webhook_router(app_state.clone()))
+        .merge(openai_webhook_router(app_state.clone()))
         .layer(ServiceBuilder::new().layer(TraceLayer::new_for_http()))
         .with_state(app_state.clone());
 

--- a/robocop-server/src/openai_webhook.rs
+++ b/robocop-server/src/openai_webhook.rs
@@ -1,0 +1,499 @@
+//! OpenAI webhook handler for batch completion events.
+//!
+//! This module handles webhooks from OpenAI following the Standard Webhooks spec.
+//! When a batch completes, OpenAI sends a webhook that triggers immediate
+//! processing instead of waiting for the polling loop.
+
+use axum::{
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::{self, Next},
+    response::{Json, Response},
+    routing::post,
+    Router,
+};
+use base64::prelude::*;
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use std::sync::Arc;
+use tracing::{error, info, warn};
+
+use crate::batch_processor::process_single_batch;
+use crate::state_machine::state::BatchId;
+use crate::AppState;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// OpenAI webhook event payload.
+///
+/// Based on the Standard Webhooks spec and OpenAI's webhook documentation.
+#[derive(Debug, Deserialize)]
+pub struct OpenAIWebhookPayload {
+    /// Always "event"
+    pub object: String,
+    /// Event ID, e.g., "evt_..."
+    pub id: String,
+    /// Event type, e.g., "batch.completed", "batch.failed"
+    #[serde(rename = "type")]
+    pub event_type: String,
+    /// Event data containing the batch information
+    pub data: OpenAIWebhookData,
+}
+
+/// Data field of the webhook event.
+#[derive(Debug, Deserialize)]
+pub struct OpenAIWebhookData {
+    /// The batch ID, e.g., "batch_abc123"
+    pub id: String,
+}
+
+/// Response returned by the webhook handler.
+#[derive(Serialize)]
+pub struct WebhookResponse {
+    pub message: String,
+}
+
+/// Maximum webhook body size (1MB).
+///
+/// Webhook payloads are typically small (under 64KB). This limit prevents
+/// memory exhaustion attacks while being generous enough for any legitimate payload.
+const MAX_WEBHOOK_BODY_SIZE: usize = 1024 * 1024;
+
+/// Maximum age of webhook timestamp (5 minutes per Standard Webhooks spec).
+///
+/// Webhooks with timestamps older than this are rejected to prevent replay attacks.
+/// The tolerance also applies to future timestamps to handle clock skew.
+const TIMESTAMP_TOLERANCE_SECONDS: i64 = 300;
+
+/// Check if a webhook timestamp is within the acceptable tolerance window.
+///
+/// Returns true if the timestamp is within `TIMESTAMP_TOLERANCE_SECONDS` of `now`.
+/// Both old timestamps (replay attacks) and future timestamps (clock skew) are checked.
+fn is_timestamp_within_tolerance(timestamp_secs: i64, now_secs: i64) -> bool {
+    (now_secs - timestamp_secs).abs() <= TIMESTAMP_TOLERANCE_SECONDS
+}
+
+/// Verify a Standard Webhooks signature using constant-time comparison.
+///
+/// Standard Webhooks format:
+/// - Secret: Base64-encoded, may have "whsec_" prefix
+/// - Headers: webhook-id, webhook-timestamp, webhook-signature
+/// - Signature format: "v1,<base64>" (may have multiple space-separated versions)
+/// - Signed payload: "{webhook-id}.{webhook-timestamp}.{body}"
+fn verify_standard_webhook_signature(
+    secret: &str,
+    webhook_id: &str,
+    timestamp: &str,
+    body: &[u8],
+    signature_header: &str,
+) -> bool {
+    // Remove "whsec_" prefix if present (OpenAI uses this prefix)
+    let secret_b64 = secret.strip_prefix("whsec_").unwrap_or(secret);
+
+    // Decode the base64-encoded secret
+    let secret_bytes = match BASE64_STANDARD.decode(secret_b64) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            error!("Failed to decode webhook secret from base64");
+            return false;
+        }
+    };
+
+    // Build the signed payload: {webhook-id}.{webhook-timestamp}.{body}
+    let body_str = String::from_utf8_lossy(body);
+    let signed_payload = format!("{}.{}.{}", webhook_id, timestamp, body_str);
+
+    // Parse the signature header - format is "v1,<base64>" or multiple space-separated
+    // versions like "v1,<sig1> v1a,<sig2>"
+    // We look for any v1 signature that matches using constant-time comparison
+    for part in signature_header.split(' ') {
+        if let Some(sig_b64) = part.strip_prefix("v1,") {
+            // Decode the provided signature from base64
+            let sig_bytes = match BASE64_STANDARD.decode(sig_b64) {
+                Ok(bytes) => bytes,
+                Err(_) => continue, // Skip malformed signatures
+            };
+
+            // Create fresh HMAC for each signature attempt and use verify_slice
+            // for constant-time comparison
+            let mut mac = match HmacSha256::new_from_slice(&secret_bytes) {
+                Ok(mac) => mac,
+                Err(_) => {
+                    error!("Failed to create HMAC from secret");
+                    return false;
+                }
+            };
+            mac.update(signed_payload.as_bytes());
+
+            // verify_slice performs constant-time comparison
+            if mac.verify_slice(&sig_bytes).is_ok() {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Middleware to verify OpenAI webhook signatures.
+async fn verify_openai_webhook_signature(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    // Check if OpenAI webhooks are configured
+    let secret = match &state.openai_webhook_secret {
+        Some(s) => s.clone(),
+        None => {
+            warn!("OpenAI webhook received but OPENAI_WEBHOOK_SECRET not configured");
+            return Err(StatusCode::SERVICE_UNAVAILABLE);
+        }
+    };
+
+    // Extract headers and body with size limit to prevent DoS
+    let (parts, body) = request.into_parts();
+    let bytes = axum::body::to_bytes(body, MAX_WEBHOOK_BODY_SIZE)
+        .await
+        .map_err(|_| {
+            error!("Webhook body too large or read error");
+            StatusCode::PAYLOAD_TOO_LARGE
+        })?;
+
+    // Extract Standard Webhooks headers
+    let webhook_id = parts
+        .headers
+        .get("webhook-id")
+        .and_then(|h| h.to_str().ok())
+        .ok_or_else(|| {
+            error!("Missing webhook-id header");
+            StatusCode::UNAUTHORIZED
+        })?;
+
+    let timestamp = parts
+        .headers
+        .get("webhook-timestamp")
+        .and_then(|h| h.to_str().ok())
+        .ok_or_else(|| {
+            error!("Missing webhook-timestamp header");
+            StatusCode::UNAUTHORIZED
+        })?;
+
+    // Validate timestamp is within tolerance window (replay protection)
+    let timestamp_secs: i64 = timestamp.parse().map_err(|_| {
+        error!("Invalid webhook-timestamp format: {}", timestamp);
+        StatusCode::UNAUTHORIZED
+    })?;
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .as_secs() as i64;
+
+    if !is_timestamp_within_tolerance(timestamp_secs, now_secs) {
+        error!(
+            "Webhook timestamp {} outside tolerance (current: {}, tolerance: {}s)",
+            timestamp_secs, now_secs, TIMESTAMP_TOLERANCE_SECONDS
+        );
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let signature = parts
+        .headers
+        .get("webhook-signature")
+        .and_then(|h| h.to_str().ok())
+        .ok_or_else(|| {
+            error!("Missing webhook-signature header");
+            StatusCode::UNAUTHORIZED
+        })?;
+
+    // Verify signature
+    if !verify_standard_webhook_signature(&secret, webhook_id, timestamp, &bytes, signature) {
+        error!("Invalid OpenAI webhook signature");
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    // Pass through to handler
+    let new_request = Request::from_parts(parts, axum::body::Body::from(bytes));
+
+    Ok(next.run(new_request).await)
+}
+
+/// Handler for OpenAI webhook events.
+pub async fn openai_webhook_handler(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Result<Json<WebhookResponse>, StatusCode> {
+    info!("Received OpenAI webhook");
+
+    // Parse body (size already validated by middleware, but apply limit for safety)
+    let (_parts, body) = request.into_parts();
+    let bytes = axum::body::to_bytes(body, MAX_WEBHOOK_BODY_SIZE)
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let payload: OpenAIWebhookPayload = serde_json::from_slice(&bytes).map_err(|e| {
+        error!("Failed to parse OpenAI webhook payload: {}", e);
+        StatusCode::BAD_REQUEST
+    })?;
+
+    info!(
+        "OpenAI webhook: type={}, batch_id={}",
+        payload.event_type, payload.data.id
+    );
+
+    // Look up which PR owns this batch
+    let batch_id = payload.data.id.clone();
+
+    let lookup_result = state.state_store.get_pr_by_batch_id(&batch_id).await;
+
+    let (pr_id, installation_id) = match lookup_result {
+        Some(result) => result,
+        None => {
+            // Batch not found - may be from CLI or already completed
+            info!(
+                "Batch {} not found in state store, ignoring webhook",
+                batch_id
+            );
+            return Ok(Json(WebhookResponse {
+                message: "Batch not tracked".to_string(),
+            }));
+        }
+    };
+
+    info!(
+        "Found PR #{} for batch {} (installation {})",
+        pr_id.pr_number, batch_id, installation_id
+    );
+
+    // Spawn background task to process the batch result
+    let state_clone = state.clone();
+    let batch_id_clone = BatchId::from(batch_id.clone());
+    let pr_id_clone = pr_id.clone();
+
+    tokio::spawn(async move {
+        if let Err(e) =
+            process_single_batch(&state_clone, &pr_id_clone, &batch_id_clone, installation_id).await
+        {
+            error!(
+                "Failed to process OpenAI webhook for batch {}: {}",
+                batch_id_clone.0, e
+            );
+        }
+    });
+
+    Ok(Json(WebhookResponse {
+        message: "Webhook received".to_string(),
+    }))
+}
+
+/// Create a router for OpenAI webhook endpoints.
+pub fn openai_webhook_router(middleware_state: Arc<AppState>) -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/openai-webhook", post(openai_webhook_handler))
+        .route_layer(middleware::from_fn_with_state(
+            middleware_state,
+            verify_openai_webhook_signature,
+        ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Official test vector from Standard Webhooks / Svix documentation:
+    // https://docs.svix.com/receiving/verifying-payloads/how-manual
+    //
+    // These values are hard-coded from the spec to ensure our implementation
+    // matches the standard, rather than computing the signature ourselves.
+    const TEST_SECRET: &str = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
+    const TEST_WEBHOOK_ID: &str = "msg_p5jXN8AQM9LWM0D4loKWxJek";
+    const TEST_TIMESTAMP: &str = "1614265330";
+    const TEST_BODY: &[u8] = br#"{"test": 2432232314}"#;
+    // Expected signature from the Standard Webhooks spec
+    const TEST_EXPECTED_SIGNATURE: &str = "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE=";
+
+    #[test]
+    fn test_verify_signature_with_spec_test_vector() {
+        // Verify against the official Standard Webhooks test vector
+        // This ensures our implementation matches the spec exactly
+        assert!(
+            verify_standard_webhook_signature(
+                TEST_SECRET,
+                TEST_WEBHOOK_ID,
+                TEST_TIMESTAMP,
+                TEST_BODY,
+                TEST_EXPECTED_SIGNATURE
+            ),
+            "Failed to verify official Standard Webhooks test vector"
+        );
+    }
+
+    #[test]
+    fn test_verify_signature_invalid() {
+        // Wrong signature should fail
+        let wrong_signature = "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+        assert!(!verify_standard_webhook_signature(
+            TEST_SECRET,
+            TEST_WEBHOOK_ID,
+            TEST_TIMESTAMP,
+            TEST_BODY,
+            wrong_signature
+        ));
+    }
+
+    #[test]
+    fn test_verify_signature_malformed_base64() {
+        // Malformed base64 in signature should fail gracefully
+        let malformed_signature = "v1,not-valid-base64!!!";
+
+        assert!(!verify_standard_webhook_signature(
+            TEST_SECRET,
+            TEST_WEBHOOK_ID,
+            TEST_TIMESTAMP,
+            TEST_BODY,
+            malformed_signature
+        ));
+    }
+
+    #[test]
+    fn test_verify_signature_wrong_body() {
+        // Valid signature for original body should fail with tampered body
+        let tampered_body = br#"{"test": 9999999999}"#;
+
+        assert!(!verify_standard_webhook_signature(
+            TEST_SECRET,
+            TEST_WEBHOOK_ID,
+            TEST_TIMESTAMP,
+            tampered_body,
+            TEST_EXPECTED_SIGNATURE
+        ));
+    }
+
+    #[test]
+    fn test_verify_signature_wrong_timestamp() {
+        // Valid signature should fail with different timestamp
+        let wrong_timestamp = "1614265331"; // Off by one second
+
+        assert!(!verify_standard_webhook_signature(
+            TEST_SECRET,
+            TEST_WEBHOOK_ID,
+            wrong_timestamp,
+            TEST_BODY,
+            TEST_EXPECTED_SIGNATURE
+        ));
+    }
+
+    #[test]
+    fn test_verify_signature_wrong_webhook_id() {
+        // Valid signature should fail with different webhook ID
+        let wrong_webhook_id = "msg_different";
+
+        assert!(!verify_standard_webhook_signature(
+            TEST_SECRET,
+            wrong_webhook_id,
+            TEST_TIMESTAMP,
+            TEST_BODY,
+            TEST_EXPECTED_SIGNATURE
+        ));
+    }
+
+    #[test]
+    fn test_verify_signature_multiple_versions() {
+        // Header with multiple signature versions - v1 should still match
+        let signature_header_with_multiple = format!("v1a,fakesig {}", TEST_EXPECTED_SIGNATURE);
+
+        assert!(verify_standard_webhook_signature(
+            TEST_SECRET,
+            TEST_WEBHOOK_ID,
+            TEST_TIMESTAMP,
+            TEST_BODY,
+            &signature_header_with_multiple
+        ));
+    }
+
+    #[test]
+    fn test_verify_signature_secret_without_prefix() {
+        // Secret without whsec_ prefix should also work
+        let secret_without_prefix = "MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
+
+        assert!(verify_standard_webhook_signature(
+            secret_without_prefix,
+            TEST_WEBHOOK_ID,
+            TEST_TIMESTAMP,
+            TEST_BODY,
+            TEST_EXPECTED_SIGNATURE
+        ));
+    }
+
+    #[test]
+    fn test_parse_webhook_payload() {
+        let json = r#"{
+            "object": "event",
+            "id": "evt_123",
+            "type": "batch.completed",
+            "data": {
+                "id": "batch_abc123"
+            }
+        }"#;
+
+        let payload: OpenAIWebhookPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.object, "event");
+        assert_eq!(payload.id, "evt_123");
+        assert_eq!(payload.event_type, "batch.completed");
+        assert_eq!(payload.data.id, "batch_abc123");
+    }
+
+    #[test]
+    fn test_timestamp_within_tolerance_current() {
+        let now = 1700000000i64;
+        // Timestamp at exactly now should be valid
+        assert!(is_timestamp_within_tolerance(now, now));
+    }
+
+    #[test]
+    fn test_timestamp_within_tolerance_slightly_old() {
+        let now = 1700000000i64;
+        // Timestamp 60 seconds ago should be valid
+        assert!(is_timestamp_within_tolerance(now - 60, now));
+    }
+
+    #[test]
+    fn test_timestamp_within_tolerance_at_boundary() {
+        let now = 1700000000i64;
+        // Timestamp exactly at tolerance boundary should be valid
+        assert!(is_timestamp_within_tolerance(
+            now - TIMESTAMP_TOLERANCE_SECONDS,
+            now
+        ));
+        assert!(is_timestamp_within_tolerance(
+            now + TIMESTAMP_TOLERANCE_SECONDS,
+            now
+        ));
+    }
+
+    #[test]
+    fn test_timestamp_outside_tolerance_too_old() {
+        let now = 1700000000i64;
+        // Timestamp just past tolerance should be rejected
+        assert!(!is_timestamp_within_tolerance(
+            now - TIMESTAMP_TOLERANCE_SECONDS - 1,
+            now
+        ));
+        // Timestamp way in the past should be rejected
+        assert!(!is_timestamp_within_tolerance(now - 3600, now));
+    }
+
+    #[test]
+    fn test_timestamp_outside_tolerance_future() {
+        let now = 1700000000i64;
+        // Timestamp just past tolerance in future should be rejected
+        assert!(!is_timestamp_within_tolerance(
+            now + TIMESTAMP_TOLERANCE_SECONDS + 1,
+            now
+        ));
+        // Timestamp way in the future should be rejected
+        assert!(!is_timestamp_within_tolerance(now + 3600, now));
+    }
+}

--- a/robocop-server/src/state_machine/repository/memory.rs
+++ b/robocop-server/src/state_machine/repository/memory.rs
@@ -78,6 +78,22 @@ impl StateRepository for InMemoryRepository {
             .map(|(id, stored)| (id.clone(), stored.clone()))
             .collect())
     }
+
+    async fn get_by_batch_id(
+        &self,
+        batch_id: &str,
+    ) -> Result<Option<(StateMachinePrId, StoredState)>, RepositoryError> {
+        let states = self.states.read().await;
+        Ok(states
+            .iter()
+            .find(|(_, stored)| {
+                stored
+                    .state
+                    .pending_batch_id()
+                    .is_some_and(|id| id.0 == batch_id)
+            })
+            .map(|(id, stored)| (id.clone(), stored.clone())))
+    }
 }
 
 #[cfg(test)]

--- a/robocop-server/src/state_machine/repository/memory.rs
+++ b/robocop-server/src/state_machine/repository/memory.rs
@@ -140,6 +140,12 @@ impl StateRepository for InMemoryRepository {
         }
     }
 
+    async fn release_webhook_claim(&self, webhook_id: &str) -> Result<(), RepositoryError> {
+        let mut seen = self.seen_webhook_ids.write().await;
+        seen.remove(webhook_id);
+        Ok(())
+    }
+
     async fn cleanup_expired_webhooks(&self, ttl_seconds: i64) -> Result<usize, RepositoryError> {
         let now = Self::now_secs();
         let cutoff = now - ttl_seconds;

--- a/robocop-server/src/state_machine/repository/mod.rs
+++ b/robocop-server/src/state_machine/repository/mod.rs
@@ -206,4 +206,20 @@ pub trait StateRepository: Send + Sync {
     /// - `Ok(vec)` with all states on success
     /// - `Err(RepositoryError)` if storage operation failed
     async fn get_all(&self) -> Result<Vec<(StateMachinePrId, StoredState)>, RepositoryError>;
+
+    /// Look up a PR by its pending batch ID.
+    ///
+    /// This is used by the OpenAI webhook handler to find which PR a batch
+    /// completion event belongs to. The lookup includes both active batches
+    /// (in `BatchPending` and `AwaitingAncestryCheck` states) and batches
+    /// that are being cancelled (in `Cancelled` state with `pending_cancel_batch_id`).
+    ///
+    /// Returns:
+    /// - `Ok(Some((id, state)))` if a PR with this batch_id is found
+    /// - `Ok(None)` if no PR has this batch_id
+    /// - `Err(RepositoryError)` if storage operation failed
+    async fn get_by_batch_id(
+        &self,
+        batch_id: &str,
+    ) -> Result<Option<(StateMachinePrId, StoredState)>, RepositoryError>;
 }

--- a/robocop-server/src/state_machine/repository/mod.rs
+++ b/robocop-server/src/state_machine/repository/mod.rs
@@ -261,6 +261,17 @@ pub trait StateRepository: Send + Sync {
     /// - `Err(RepositoryError)` if storage operation failed
     async fn try_claim_webhook_id(&self, webhook_id: &str) -> Result<bool, RepositoryError>;
 
+    /// Release a claimed webhook ID to allow retries.
+    ///
+    /// This should be called when processing fails after successfully claiming
+    /// the webhook. Releasing allows OpenAI's retry mechanism to work: the same
+    /// webhook ID will be accepted on the next attempt.
+    ///
+    /// Returns:
+    /// - `Ok(())` on success (whether or not the ID existed)
+    /// - `Err(RepositoryError)` if storage operation failed
+    async fn release_webhook_claim(&self, webhook_id: &str) -> Result<(), RepositoryError>;
+
     /// Clean up expired webhook IDs.
     ///
     /// This is called periodically or opportunistically to remove webhook IDs

--- a/robocop-server/src/state_machine/repository/mod.rs
+++ b/robocop-server/src/state_machine/repository/mod.rs
@@ -249,6 +249,18 @@ pub trait StateRepository: Send + Sync {
     /// - `Err(RepositoryError)` if storage operation failed
     async fn record_webhook_id(&self, webhook_id: &str) -> Result<(), RepositoryError>;
 
+    /// Atomically try to claim a webhook ID for processing.
+    ///
+    /// This combines the check and record operations into a single atomic
+    /// operation to prevent race conditions where concurrent requests both
+    /// pass the "is_webhook_seen" check before either records.
+    ///
+    /// Returns:
+    /// - `Ok(true)` if this caller successfully claimed the webhook (first to see it)
+    /// - `Ok(false)` if the webhook was already claimed by another caller (replay)
+    /// - `Err(RepositoryError)` if storage operation failed
+    async fn try_claim_webhook_id(&self, webhook_id: &str) -> Result<bool, RepositoryError>;
+
     /// Clean up expired webhook IDs.
     ///
     /// This is called periodically or opportunistically to remove webhook IDs

--- a/robocop-server/src/state_machine/store.rs
+++ b/robocop-server/src/state_machine/store.rs
@@ -447,7 +447,7 @@ impl StateStore {
     /// Returns `true` if this caller successfully claimed the webhook (first
     /// to see it), `false` if already claimed (replay).
     ///
-    /// On storage error, returns `false` (fail open: allow through since the
+    /// On storage error, returns `true` (fail open: allow through since the
     /// signature already validated the webhook is legitimate).
     pub async fn try_claim_webhook_id(&self, webhook_id: &str) -> bool {
         match self.repository.try_claim_webhook_id(webhook_id).await {


### PR DESCRIPTION
We should consider making this more asynchronous; OpenAI docs say we must respond immediately to webhooks, but actually we submit a new batch and update GitHub comments and checks before responding. Keep an eye out.